### PR TITLE
feat: integrate tailwind css utilities into next template

### DIFF
--- a/src/crew/tools.ts
+++ b/src/crew/tools.ts
@@ -403,7 +403,11 @@ export async function writeGlobalsCss(paths: ProjectPaths, css: string): Promise
 }
 
 export function baseGlobalsCss(): string {
-  return `:root {
+  return `@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
   /* LAPIDATTO::TOKENS_START */
   --font-family-base: 'Inter', sans-serif;
   --font-family-headings: 'Clash Display', sans-serif;
@@ -424,59 +428,75 @@ export function baseGlobalsCss(): string {
   /* LAPIDATTO::TOKENS_END */
 }
 
-body {
-  margin: 0;
-  font-family: var(--font-family-base);
-  background: var(--color-background);
-  color: var(--color-foreground);
-}
-
-*, *::before, *::after {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
 }
 
-.bg-card {
-  background: var(--color-surface);
+html {
+  text-size-adjust: 100%;
+  font-feature-settings: "rlig" 1, "kern" 1;
 }
 
-.bg-muted {
-  background: var(--color-muted);
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: var(--font-family-base);
+  background-color: var(--color-background);
+  color: var(--color-foreground);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
 }
 
-.bg-surface {
-  background: var(--color-surface);
+a {
+  color: inherit;
+  text-decoration: none;
 }
 
-.text-muted-foreground {
-  color: color-mix(in srgb, var(--color-foreground) 65%, white 35%);
+img,
+picture,
+video,
+canvas,
+svg {
+  display: block;
+  max-width: 100%;
 }
 
-.text-primary {
-  color: var(--color-primary);
+button,
+input,
+textarea,
+select {
+  font: inherit;
+  color: inherit;
 }
 
-.text-primary-foreground {
-  color: var(--color-primary-foreground);
+:where(button) {
+  background: none;
+  border: none;
+  padding: 0;
 }
 
-.border-border {
-  border-color: var(--color-border);
+[role="button"],
+button {
+  cursor: pointer;
 }
 
-.rounded-2xl {
-  border-radius: var(--radius-md);
+.bg-primary\/10 {
+  background-color: color-mix(in srgb, var(--color-primary) 10%, transparent);
 }
 
-.rounded-3xl {
-  border-radius: var(--radius-lg);
-}
-
-.shadow-sm {
-  box-shadow: var(--shadow-sm);
-}
-
-.shadow-lg {
-  box-shadow: var(--shadow-md);
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }
 `;
 }

--- a/src/templates/nextjs-base/app/globals.css
+++ b/src/templates/nextjs-base/app/globals.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 :root {
   /* LAPIDATTO::TOKENS_START */
   --font-family-base: 'Inter', sans-serif;
@@ -19,57 +23,73 @@
   /* LAPIDATTO::TOKENS_END */
 }
 
-body {
-  margin: 0;
-  font-family: var(--font-family-base);
-  background: var(--color-background);
-  color: var(--color-foreground);
-}
-
-*, *::before, *::after {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
 }
 
-.bg-card {
-  background: var(--color-surface);
+html {
+  text-size-adjust: 100%;
+  font-feature-settings: "rlig" 1, "kern" 1;
 }
 
-.bg-muted {
-  background: var(--color-muted);
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: var(--font-family-base);
+  background-color: var(--color-background);
+  color: var(--color-foreground);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
 }
 
-.bg-surface {
-  background: var(--color-surface);
+a {
+  color: inherit;
+  text-decoration: none;
 }
 
-.text-muted-foreground {
-  color: color-mix(in srgb, var(--color-foreground) 65%, white 35%);
+img,
+picture,
+video,
+canvas,
+svg {
+  display: block;
+  max-width: 100%;
 }
 
-.text-primary {
-  color: var(--color-primary);
+button,
+input,
+textarea,
+select {
+  font: inherit;
+  color: inherit;
 }
 
-.text-primary-foreground {
-  color: var(--color-primary-foreground);
+:where(button) {
+  background: none;
+  border: none;
+  padding: 0;
 }
 
-.border-border {
-  border-color: var(--color-border);
+[role="button"],
+button {
+  cursor: pointer;
 }
 
-.rounded-2xl {
-  border-radius: var(--radius-md);
+.bg-primary\/10 {
+  background-color: color-mix(in srgb, var(--color-primary) 10%, transparent);
 }
 
-.rounded-3xl {
-  border-radius: var(--radius-lg);
-}
-
-.shadow-sm {
-  box-shadow: var(--shadow-sm);
-}
-
-.shadow-lg {
-  box-shadow: var(--shadow-md);
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/src/templates/nextjs-base/package.json
+++ b/src/templates/nextjs-base/package.json
@@ -10,16 +10,22 @@
     "test": "echo \"Tests serão adicionados pelo QA\""
   },
   "dependencies": {
+    "class-variance-authority": "0.7.0",
+    "clsx": "2.1.0",
     "next": "14.1.0",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "tailwind-merge": "2.2.1"
   },
   "devDependencies": {
     "@types/node": "20.11.30",
     "@types/react": "18.2.21",
     "@types/react-dom": "18.2.7",
+    "autoprefixer": "10.4.17",
     "eslint": "8.56.0",
     "eslint-config-next": "14.1.0",
+    "postcss": "8.4.38",
+    "tailwindcss": "3.4.3",
     "typescript": "5.4.2"
   }
 }

--- a/src/templates/nextjs-base/postcss.config.mjs
+++ b/src/templates/nextjs-base/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/templates/nextjs-base/tailwind.config.ts
+++ b/src/templates/nextjs-base/tailwind.config.ts
@@ -1,0 +1,66 @@
+type TailwindConfig = {
+  content: string[];
+  theme?: {
+    extend?: {
+      colors?: Record<string, string | Record<string, string>>;
+      borderRadius?: Record<string, string>;
+      boxShadow?: Record<string, string>;
+      fontFamily?: Record<string, string | string[]>;
+      spacing?: Record<string, string>;
+    };
+  };
+  plugins?: unknown[];
+};
+
+const config: TailwindConfig = {
+  content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        background: "var(--color-background)",
+        foreground: "var(--color-foreground)",
+        surface: "var(--color-surface)",
+        card: {
+          DEFAULT: "var(--color-surface)",
+          foreground: "var(--color-foreground)",
+        },
+        border: "var(--color-border)",
+        primary: {
+          DEFAULT: "var(--color-primary)",
+          foreground: "var(--color-primary-foreground)",
+        },
+        muted: {
+          DEFAULT: "var(--color-muted)",
+          foreground:
+            "color-mix(in srgb, var(--color-foreground) 65%, white 35%)",
+        },
+      },
+      borderRadius: {
+        lg: "var(--radius-lg)",
+        md: "var(--radius-md)",
+        sm: "var(--radius-sm)",
+        "2xl": "var(--radius-md)",
+        "3xl": "var(--radius-lg)",
+      },
+      boxShadow: {
+        sm: "var(--shadow-sm)",
+        lg: "var(--shadow-md)",
+      },
+      fontFamily: {
+        sans: ["var(--font-family-base)", "system-ui", "sans-serif"],
+        heading: [
+          "var(--font-family-headings)",
+          "var(--font-family-base)",
+          "sans-serif",
+        ],
+      },
+      spacing: {
+        4: "var(--space-4)",
+        6: "var(--space-6)",
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- add Tailwind, PostCSS and related utilities to the Next.js base template dependencies
- scaffold Tailwind and PostCSS config files that surface Lapidatto tokens via theme extensions
- refresh globals.css and baseGlobalsCss with Tailwind directives, a modern reset and token injection markers plus a helper class for translucent primary backgrounds

## Testing
- npm run lint *(fails: missing local type packages because installing dependencies is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cddd03e5148333aabac49acd6075c7